### PR TITLE
Improve posts extension with slugs, filename as default slug, and config-based default for layout

### DIFF
--- a/lib/tableau/extensions/post_extension.ex
+++ b/lib/tableau/extensions/post_extension.ex
@@ -117,7 +117,7 @@ defmodule Tableau.PostExtension do
 
   ## URL generation
 
-  If a `:permalink` is specified in the front matter, whatever is there _will_ be the post's permalink, regardless of presence of `:slug`
+  If a `:permalink` is specified in the front matter, whatever is there _will_ be the post's permalink.
 
   If a global `:permalink` is set, it's rules will be used. See `Tableau.PostExtension.Config` for details.
 

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,6 @@ defmodule Tableau.MixProject do
       {:makeup_elixir, ">= 0.0.0"},
       {:tz, "~> 0.26.2"},
 
-
       # {:yaml_front_matter, "~> 1.0"},
       # {:jason, "~> 1.4"},
       # {:req, "~> 0.3", only: :test},


### PR DESCRIPTION
Changes up a bit of logic in the posts extension to support very thin frontmatters, aiming for some defaults common to other SSGs

- If permalink is supplied, permalink is where the "post" is generated. No questions asked
- If a slug is supplied, a config value of `path` is read. Default is `posts/:slug`. Post is placed at this path
- If no value for permalink or slug is provided, filename, stripped of its extension and path components, is used, with the configured default path


This lets you write posts like this:

```md
---
id: Post.4
title: "My new blogpost"
date: "~N[2023-10-27T21:06:43-06:00]"
---

Welcome to my blog!
```

And have it show up at a normal default spot in your routing tree.
