### PR TITLE
feat: automatically generate post ids

### DIFF
--- a/lib/tableau/extensions/page_extension/pages/page.ex
+++ b/lib/tableau/extensions/page_extension/pages/page.ex
@@ -5,6 +5,8 @@ defmodule Tableau.PageExtension.Pages.Page do
       Tableau.PageExtension.Config.new(Map.new(Application.get_env(:tableau, Tableau.PageExtension, %{})))
 
     attrs
+    |> Map.put(:__tableau_page_extension__, true)
+    |> Map.put(:module, :"#{System.unique_integer()}")
     |> Map.put(:body, body)
     |> Map.put(:file, filename)
     |> Map.put(:layout, Module.concat([attrs.layout || page_config.layout]))

--- a/lib/tableau/extensions/page_extension/pages/page.ex
+++ b/lib/tableau/extensions/page_extension/pages/page.ex
@@ -6,7 +6,6 @@ defmodule Tableau.PageExtension.Pages.Page do
 
     attrs
     |> Map.put(:__tableau_page_extension__, true)
-    |> Map.put(:module, :"#{System.unique_integer()}")
     |> Map.put(:body, body)
     |> Map.put(:file, filename)
     |> Map.put(:layout, Module.concat([attrs.layout || page_config.layout]))

--- a/lib/tableau/extensions/post_extension.ex
+++ b/lib/tableau/extensions/post_extension.ex
@@ -8,7 +8,7 @@ defmodule Tableau.PostExtension do
 
   Frontmatter is compiled with `yaml_elixir` and all keys are converted to atoms.
 
-  * `:id` - An Elixir module to be used when compiling the backing `Tableau.Page`. A leaking implementation detail that should be fixed eventually.
+  * `:id` - An Elixir module to be used when compiling the backing `Tableau.Page`. Optional.
   * `:title` - The title of the post. Falls back to the first `<h1>` tag if present in the body.
   * `:permalink` - The permalink of the post. `:title` will be replaced with the posts title and non alphanumeric characters removed. Optional.
   * `:date` - A string representation of an Elixir `NaiveDateTime`, often presented as a `sigil_N`. This will be converted to your configured timezone.
@@ -90,9 +90,13 @@ defmodule Tableau.PostExtension do
 
         posts =
           for post <- apply(Tableau.PostExtension.Posts, :posts, []) do
+            post_id =
+              post.id ||
+                post.title |> String.replace(~r/[^[:alnum:]]+/u, "_") |> Macro.camelize() |> then(&("Post." <> &1))
+
             {:module, _module, _binary, _term} =
               Module.create(
-                Module.concat([post.id]),
+                Module.concat([post_id]),
                 quote do
                   use Tableau.Page, unquote(Macro.escape(Keyword.new(post)))
 

--- a/lib/tableau/extensions/post_extension/posts/post.ex
+++ b/lib/tableau/extensions/post_extension/posts/post.ex
@@ -7,6 +7,7 @@ defmodule Tableau.PostExtension.Posts.Post do
       Tableau.PostExtension.Config.new(Map.new(Application.get_env(:tableau, Tableau.PostExtension, %{})))
 
     attrs
+    |> Map.put(:__tableau_post_extension__, true)
     |> Map.put(:body, body)
     |> Map.put(:file, filename)
     |> Map.put(:layout, Module.concat([attrs[:layout] || post_config.layout]))
@@ -18,7 +19,6 @@ defmodule Tableau.PostExtension.Posts.Post do
         _ -> nil
       end
     end)
-    |> maybe_calculate_id()
     |> Map.put(
       :date,
       DateTime.from_naive!(
@@ -67,16 +67,5 @@ defmodule Tableau.PostExtension.Posts.Post do
     |> String.replace(" ", "-")
     |> String.replace(~r/[^[:alnum:]\/\-]/, "")
     |> String.downcase()
-  end
-
-  defp maybe_calculate_id(%{id: _} = attrs), do: attrs
-
-  defp maybe_calculate_id(attrs) do
-    attrs.title
-    |> String.downcase()
-    |> String.replace(~r/[^[:alnum:]]+/u, "_")
-    |> Macro.camelize()
-    |> then(&"AutogenPostID.#{&1}")
-    |> then(&Map.put(attrs, :id, &1))
   end
 end

--- a/lib/tableau/extensions/post_extension/posts/post.ex
+++ b/lib/tableau/extensions/post_extension/posts/post.ex
@@ -18,6 +18,7 @@ defmodule Tableau.PostExtension.Posts.Post do
         _ -> nil
       end
     end)
+    |> maybe_calculate_id()
     |> Map.put(
       :date,
       DateTime.from_naive!(
@@ -66,5 +67,16 @@ defmodule Tableau.PostExtension.Posts.Post do
     |> String.replace(" ", "-")
     |> String.replace(~r/[^[:alnum:]\/\-]/, "")
     |> String.downcase()
+  end
+
+  defp maybe_calculate_id(%{id: _} = attrs), do: attrs
+
+  defp maybe_calculate_id(attrs) do
+    attrs.title
+    |> String.downcase()
+    |> String.replace(~r/[^[:alnum:]]+/u, "_")
+    |> Macro.camelize()
+    |> then(&"AutogenPostID.#{&1}")
+    |> then(&Map.put(attrs, :id, &1))
   end
 end


### PR DESCRIPTION
Generates the post IDs from the title, if they are not specified by the frontmatter.

Generated IDs are the title, stripped of all non-alphanums, camelized, and prefixed with `Post.`
