### PR TITLE
feat: fall back to first <h1> as title if no title in frontmatter

### DIFF
--- a/lib/tableau/extensions/page_extension/pages/page.ex
+++ b/lib/tableau/extensions/page_extension/pages/page.ex
@@ -8,6 +8,14 @@ defmodule Tableau.PageExtension.Pages.Page do
     |> Map.put(:body, body)
     |> Map.put(:file, filename)
     |> Map.put(:layout, Module.concat([attrs.layout || page_config.layout]))
+    |> Map.put_new_lazy(:title, fn ->
+      with {:ok, document} <- Floki.parse_fragment(body),
+           [hd | _] <- Floki.find(document, "h1") do
+        Floki.text(hd)
+      else
+        _ -> nil
+      end
+    end)
     |> build_permalink(page_config)
   end
 

--- a/lib/tableau/extensions/post_extension.ex
+++ b/lib/tableau/extensions/post_extension.ex
@@ -9,7 +9,7 @@ defmodule Tableau.PostExtension do
   Frontmatter is compiled with `yaml_elixir` and all keys are converted to atoms.
 
   * `:id` - An Elixir module to be used when compiling the backing `Tableau.Page`. A leaking implementation detail that should be fixed eventually.
-  * `:title` - The title of the post
+  * `:title` - The title of the post. If absent and the post starts with a h1 (markdown `#`), then that is used as the post title.
   * `:permalink` - The permalink of the post. `:title` will be replaced with the posts title and non alphanumeric characters removed. Optional.
   * `:date` - A string representation of an Elixir `NaiveDateTime`, often presented as a `sigil_N`. This will be converted to your configured timezone.
   * `:layout` - A string representation of a Tableau layout module.

--- a/lib/tableau/extensions/post_extension.ex
+++ b/lib/tableau/extensions/post_extension.ex
@@ -9,7 +9,7 @@ defmodule Tableau.PostExtension do
   Frontmatter is compiled with `yaml_elixir` and all keys are converted to atoms.
 
   * `:id` - An Elixir module to be used when compiling the backing `Tableau.Page`. A leaking implementation detail that should be fixed eventually.
-  * `:title` - The title of the post. If absent and the post starts with a h1 (markdown `#`), then that is used as the post title.
+  * `:title` - The title of the post. Falls back to the first `<h1>` tag if present in the body.
   * `:permalink` - The permalink of the post. `:title` will be replaced with the posts title and non alphanumeric characters removed. Optional.
   * `:date` - A string representation of an Elixir `NaiveDateTime`, often presented as a `sigil_N`. This will be converted to your configured timezone.
   * `:layout` - A string representation of a Tableau layout module.

--- a/lib/tableau/extensions/post_extension/posts/post.ex
+++ b/lib/tableau/extensions/post_extension/posts/post.ex
@@ -11,8 +11,10 @@ defmodule Tableau.PostExtension.Posts.Post do
     |> Map.put(:file, filename)
     |> Map.put(:layout, Module.concat([attrs.layout || post_config.layout]))
     |> Map.put_new_lazy(:title, fn ->
-      case Floki.parse_fragment(body) do
-        {:ok, [{"h1", _, _} = head | _]} -> Floki.text(head)
+      with {:ok, document} <- Floki.parse_fragment(body),
+           [hd | _] <- Floki.find(document, "h1") do
+        Floki.text(hd)
+      else
         _ -> nil
       end
     end)

--- a/lib/tableau/extensions/post_extension/posts/post.ex
+++ b/lib/tableau/extensions/post_extension/posts/post.ex
@@ -10,6 +10,12 @@ defmodule Tableau.PostExtension.Posts.Post do
     |> Map.put(:body, body)
     |> Map.put(:file, filename)
     |> Map.put(:layout, Module.concat([attrs.layout || post_config.layout]))
+    |> Map.put_new_lazy(:title, fn ->
+      case Floki.parse_fragment(body) do
+        {:ok, [{"h1", _, _} = head | _]} -> Floki.text(head)
+        _ -> nil
+      end
+    end)
     |> Map.put(
       :date,
       DateTime.from_naive!(

--- a/mix.exs
+++ b/mix.exs
@@ -43,11 +43,11 @@ defmodule Tableau.MixProject do
       {:web_dev_utils, "~> 0.1"},
       {:websock_adapter, "~> 0.5"},
       {:yaml_elixir, "~> 2.9"},
+      {:floki, "~> 0.34"},
 
       # dev
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:styler, "~> 0.9", only: :dev},
-      {:floki, "~> 0.34", only: :test}
+      {:styler, "~> 0.9", only: :dev}
     ]
   end
 


### PR DESCRIPTION
Read the post title from the first node of a post, IF the first node is a `h1` AND IF post frontmatter `title` is absent

Lets you write posts like this:

```
---
date: "~N[2023-10-27T20:40:58-06:00]"
---

# My Awesome Post
```

This is a pattern used by Hugo, Nuxt-Content, and other SSGs
