### PR TITLE
feat: configurable h1 stripping for autogen titles

### DIFF
--- a/lib/tableau/extensions/post_extension.ex
+++ b/lib/tableau/extensions/post_extension.ex
@@ -39,6 +39,7 @@ defmodule Tableau.PostExtension do
   - `:future` - boolean - Show posts that have dates later than the current timestamp, or time at which the site is generated.
   - `:permalink` - string - Default output path for posts. Accepts `:title` as a replacement keyword, replaced with the post's provided title. If a post has a `:permalink` provided, that will override this value _for that post_.
   - `:layout` - string - Elixir module providing page layout for posts. Default is nil
+  - `:strip_h1_titles` - boolean - Strip the first h1 encountered in the document if no `title` frontmatter is specified and the title is auto-generated. Optional
 
   ### Example
 

--- a/lib/tableau/extensions/post_extension/config.ex
+++ b/lib/tableau/extensions/post_extension/config.ex
@@ -3,7 +3,7 @@ defmodule Tableau.PostExtension.Config do
 
   import Schematic
 
-  defstruct enabled: true, dir: "_posts", future: false, permalink: nil, layout: nil
+  defstruct enabled: true, dir: "_posts", future: false, permalink: nil, layout: nil, strip_h1_titles: false
 
   def new(input), do: unify(schematic(), input)
 
@@ -15,7 +15,8 @@ defmodule Tableau.PostExtension.Config do
         optional(:dir) => str(),
         optional(:future) => bool(),
         optional(:permalink) => str(),
-        optional(:layout) => str()
+        optional(:layout) => str(),
+        optional(:strip_h1_titles) => bool()
       },
       convert: false
     )


### PR DESCRIPTION
Adds a configuration option to strip out the first `h1` in a document if its used for automatic title generation.

Prevents cases where a document winds up with two "titles" being rendered, like this:

<img width="631" alt="CleanShot 2023-11-07 at 20 04 12@2x" src="https://github.com/elixir-tools/tableau/assets/168193/23c9c6c3-f51f-4cfa-82d4-c22c2943536c">
