### PR TITLE
Fix RSS double-protocols

### DIFF
--- a/lib/tableau/extensions/rss_extension.ex
+++ b/lib/tableau/extensions/rss_extension.ex
@@ -40,9 +40,9 @@ defmodule Tableau.RSSExtension do
         """
             <item>
                <title>#{post.title}</title>
-               <link>https://#{Path.join(url, post.permalink)}</link>
+               <link>#{URI.merge(url, post.permalink)}</link>
                <pubDate>#{Calendar.strftime(post.date, "%a, %d %b %Y %X %Z")}</pubDate>
-               <guid>http://#{Path.join(url, post.permalink)}</guid>
+               <guid>#{URI.merge(url, post.permalink)}</guid>
                <description><![CDATA[ #{post.body} ]]></description>
             </item>
         """


### PR DESCRIPTION
If you set the tableau URL to include a protocol, i.e. `https://yoursite.com/`, the RSS feeds will generate links that look like `https://https//yoursite.com`. This removes the hard-coded `https://` from the RSS link generation

