### PR TITLE
docs: add Tableau websites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,13 @@ end
 
 Documentation can be found at <https://hexdocs.pm/tableau>.
 
-## Tableau Demo Sites 
+## Built with Tableau
 
 | Site                                                 | Template    | Source                                                                            |
 |------------------------------------------------------|-------------|-----------------------------------------------------------------------------------|
-| [www.elixir-tools.dev](https://www.elixir-tools.dev) | [temple][1] | [elixir-tools/elixir-tools.dev](https://github.com/elixir-tools/elixir-tools.dev) |
-| [pdx.su](https://pdx.su)                             | [temple][1] | [paradox460/pdx.su](https://github.com/paradox460/pdx.su)                         |
-| HEEX Demo                                            | [heex][2]   | [mhanberg/tableau_demo_heex](https://github.com/mhanberg/tableau_demo_heex)       |
-
-[1]: https://github.com/mhanberg/temple 
-[2]: https://www.google.com/search?q=elixir+liveview+heex 
+| [www.elixir-tools.dev](https://www.elixir-tools.dev) | [Temple](https://github.com/mhanberg/temple) | [elixir-tools/elixir-tools.dev](https://github.com/elixir-tools/elixir-tools.dev) |
+| [pdx.su](https://pdx.su)                             | [Temple](https://github.com/mhanberg/temple) | [paradox460/pdx.su](https://github.com/paradox460/pdx.su)                         |
+| HEEx Demo                                            | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2)   | [mhanberg/tableau_demo_heex](https://github.com/mhanberg/tableau_demo_heex)       |
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,16 @@ end
 
 Documentation can be found at <https://hexdocs.pm/tableau>.
 
-## Demo
+## Tableau Demo Sites 
 
-For a real world demo of Tableau, you can see [www.elixir-tools.dev](https://www.elixir-tools.dev) ([source code](https://github.com/elixir-tools/elixir-tools.dev)).
+| Site                                                 | Template    | Source                                                                            |
+|------------------------------------------------------|-------------|-----------------------------------------------------------------------------------|
+| [www.elixir-tools.dev](https://www.elixir-tools.dev) | [temple][1] | [elixir-tools/elixir-tools.dev](https://github.com/elixir-tools/elixir-tools.dev) |
+| [pdx.su](https://pdx.su)                             | [temple][1] | [paradox460/pdx.su](https://github.com/paradox460/pdx.su)                         |
+| HEEX Demo                                            | [heex][2]   | [mhanberg/tableau_demo_heex](https://github.com/mhanberg/tableau_demo_heex)       |
+
+[1]: https://github.com/mhanberg/temple 
+[2]: https://www.google.com/search?q=elixir+liveview+heex 
 
 ## Getting Started
 


### PR DESCRIPTION
Updated README.md file with links to three Tableau demo sites.  (2 using temple, 1 using heex)