### PR TITLE
fix: rss moduledoc

### DIFF
--- a/lib/tableau/extensions/rss_extension.ex
+++ b/lib/tableau/extensions/rss_extension.ex
@@ -1,8 +1,6 @@
 defmodule Tableau.RSSExtension do
   @moduledoc """
-  YAML files and Elixir scripts (.exs) in the configured directory will be automatically parsed/executed and made available in an `@data` assign in your templates.
-
-  Elixir scripts will be executed and the last expression returned as the data.
+  Generate RSS data and write to `_site/feed.xml`.
 
   ## Configuration
 


### PR DESCRIPTION
It looks like the  moduledoc for `rss_extension.ex` was copied from `data_extension.ex`.

Just a small tweak to make the documentation more accurate...