### PR TITLE
feat: basepath routing for DevServer vhost emulation 

### DIFF
--- a/lib/mix/tasks/tableau.server.ex
+++ b/lib/mix/tasks/tableau.server.ex
@@ -19,9 +19,6 @@ defmodule Mix.Tasks.Tableau.Server do
   end
 
   defp basepath do
-    case Application.get_env(:tableau, :config)[:base_path] do
-      "" -> ""
-      path -> Path.join("/", path)
-    end
+    Path.join("/", Application.get_env(:tableau, :config)[:base_path])
   end
 end

--- a/lib/mix/tasks/tableau.server.ex
+++ b/lib/mix/tasks/tableau.server.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Tableau.Server do
   defp basepath do
     case Application.get_env(:tableau, :config)[:base_path] do
       "" -> ""
-      path -> "/" <> path
+      path -> Path.join("/", path)
     end
   end
 end

--- a/lib/mix/tasks/tableau.server.ex
+++ b/lib/mix/tasks/tableau.server.ex
@@ -19,6 +19,6 @@ defmodule Mix.Tasks.Tableau.Server do
   end
 
   defp basepath do
-    Path.join("/", Application.get_env(:tableau, :config)[:base_path])
+    Path.join("/", Application.get_env(:tableau, :config)[:base_path] || "")
   end
 end

--- a/lib/mix/tasks/tableau.server.ex
+++ b/lib/mix/tasks/tableau.server.ex
@@ -11,10 +11,17 @@ defmodule Mix.Tasks.Tableau.Server do
     Application.put_env(:tableau, :server, true)
     Code.put_compiler_option(:ignore_module_conflict, true)
 
-    Logger.debug("server started on http://localhost:4999")
+    Logger.debug("server started on http://localhost:4999#{basepath()}")
 
     Mix.Task.run("app.start", ["--preload-modules"])
 
     Mix.Tasks.Run.run(["--no-halt"])
+  end
+
+  defp basepath do
+    case Application.get_env(:tableau, :config)[:base_path] do
+      "" -> ""
+      path -> "/" <> path
+    end
   end
 end

--- a/lib/tableau.ex
+++ b/lib/tableau.ex
@@ -4,7 +4,7 @@ defmodule Tableau do
 
   * `:include_dir` - string - Directory that is just copied to the output directory. Defaults to `extra`.
   * `:timezone` - string - Timezone to use when parsing date times. Defaults to `Etc/UTC`.
-  * `:base_path - string - base path to use with Github Pages or web-servers that use a location prefix for Vhosts
+  * `:base_path - string - Development server root.  Defaults to '/'.
   * `:url` - string (required) - The URL of your website.
   * `:markdown` - keyword
       * `:mdex` - keyword - Options to pass to `MDEx.to_html/2`

--- a/lib/tableau.ex
+++ b/lib/tableau.ex
@@ -8,65 +8,6 @@ defmodule Tableau do
   * `:url` - string (required) - The URL of your website.
   * `:markdown` - keyword
       * `:mdex` - keyword - Options to pass to `MDEx.to_html/2`
-
-  ## Working with Github Pages or web-server Vhosts
-
-  Github Pages provides a root url like `https://andyl.github.io/xmeyers`, where
-  the `xmeyers` prefix is a virtual host identifier tied to the repo at
-  `https://github.com/andyl/xmeyers`.
-
-  With Nginx and Apache it is common to use a location prefix for Vhosts.
-  Here is an example NGINX config snippet:
-
-  ```
-  server {
-    listen 80;
-    server_name myhost.com;
-
-    location /site1 {
-        # Configuration for site1 - eg the root directive to a directory
-        # root /var/www/site1;
-    }
-
-    location /site2 {
-        # Configuration for site2
-        # Similar configuration as site1, adjusted for site2 specifics
-    }
-
-    # Other configuration...
-  }
-  ```
-
-  To make Tableau's development server (`mix tableau.server`) also use a Vost
-  prefix, configure your app with the `:base_path` attribute.  With that, your
-  website HREFs will work in both development and production.
-
-  ## Example
-
-  In `config/config.exs`:
-
-  ```elixir
-  config :tableau, :config,
-    url: "http://localhost:4999",
-    base_path: "xmeyers",
-    markdown: [
-      ...
-    ]
-  ```
-
-  In `root_layout.ex`:
-
-  ```elixir
-  def template(assigns) do
-    ~H\"""
-    <!DOCTYPE html>
-    <html>
-      <head>
-        <title>Xmeyers</title>
-        <link rel="icon" href="/xmeyers/static/img/favicon.ico" type="image/x-icon" />
-        <link rel="stylesheet" type="text/css" href="/xmeyers/css/site.css" />
-     ...
-  ```
   """
 
   @doc """

--- a/lib/tableau.ex
+++ b/lib/tableau.ex
@@ -4,9 +4,69 @@ defmodule Tableau do
 
   * `:include_dir` - string - Directory that is just copied to the output directory. Defaults to `extra`.
   * `:timezone` - string - Timezone to use when parsing date times. Defaults to `Etc/UTC`.
+  * `:base_path - string - base path to use with Github Pages or web-servers that use a location prefix for Vhosts
   * `:url` - string (required) - The URL of your website.
   * `:markdown` - keyword
       * `:mdex` - keyword - Options to pass to `MDEx.to_html/2`
+
+  ## Working with Github Pages or web-server Vhosts
+
+  Github Pages provides a root url like `https://andyl.github.io/xmeyers`, where
+  the `xmeyers` prefix is a virtual host identifier tied to the repo at
+  `https://github.com/andyl/xmeyers`.
+
+  With Nginx and Apache it is common to use a location prefix for Vhosts.
+  Here is an example NGINX config snippet:
+
+  ```
+  server {
+    listen 80;
+    server_name myhost.com;
+
+    location /site1 {
+        # Configuration for site1 - eg the root directive to a directory
+        # root /var/www/site1;
+    }
+
+    location /site2 {
+        # Configuration for site2
+        # Similar configuration as site1, adjusted for site2 specifics
+    }
+
+    # Other configuration...
+  }
+  ```
+
+  To make Tableau's development server (`mix tableau.server`) also use a Vost
+  prefix, configure your app with the `:base_path` attribute.  With that, your
+  website HREFs will work in both development and production.
+
+  ## Example
+
+  In `config/config.exs`:
+
+  ```elixir
+  config :tableau, :config,
+    url: "http://localhost:4999",
+    base_path: "xmeyers",
+    markdown: [
+      ...
+    ]
+  ```
+
+  In `root_layout.ex`:
+
+  ```elixir
+  def template(assigns) do
+    ~H"""
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Xmeyers</title>
+        <link rel="icon" href="/xmeyers/static/img/favicon.ico" type="image/x-icon" />
+        <link rel="stylesheet" type="text/css" href="/xmeyers/css/site.css" />
+     ...
+  ```
   """
 
   @doc """

--- a/lib/tableau.ex
+++ b/lib/tableau.ex
@@ -58,7 +58,7 @@ defmodule Tableau do
 
   ```elixir
   def template(assigns) do
-    ~H"""
+    ~H\"""
     <!DOCTYPE html>
     <html>
       <head>

--- a/lib/tableau/config.ex
+++ b/lib/tableau/config.ex
@@ -5,6 +5,7 @@ defmodule Tableau.Config do
 
   defstruct [
     :url,
+    base_path: "",
     include_dir: "extra",
     timezone: "Etc/UTC",
     reload_log: false,

--- a/lib/tableau/router.ex
+++ b/lib/tableau/router.ex
@@ -6,7 +6,7 @@ defmodule Tableau.Router do
 
   require Logger
 
-  @base_path Path.join("/", Application.compile_env(:tableau, :config)[:base_path] || "")
+  @base_path Path.join("/", Application.compile_env(:tableau, [:config, :base_path], ""))
 
   @not_found ~g'''
   <!DOCTYPE html><html lang="en"><head></head><body>Not Found</body></html>

--- a/lib/tableau/router.ex
+++ b/lib/tableau/router.ex
@@ -6,7 +6,7 @@ defmodule Tableau.Router do
 
   require Logger
 
-  basepath = Application.get_env(:tableau, :config)[:base_path]
+  @base_path Path.join("/", Application.compile_env(:tableau, :config)[:base_path] || "")
 
   @not_found ~g'''
   <!DOCTYPE html><html lang="en"><head></head><body>Not Found</body></html>
@@ -16,7 +16,7 @@ defmodule Tableau.Router do
   plug :rerender
 
   plug Tableau.IndexHtml
-  plug Plug.Static, at: "/#{basepath}", from: "_site", cache_control_for_etags: "no-cache"
+  plug Plug.Static, at: @base_path, from: "_site", cache_control_for_etags: "no-cache"
 
   plug :match
   plug :dispatch

--- a/lib/tableau/router.ex
+++ b/lib/tableau/router.ex
@@ -6,6 +6,8 @@ defmodule Tableau.Router do
 
   require Logger
 
+  basepath = Application.get_env(:tableau, :config)[:base_path]
+
   @not_found ~g'''
   <!DOCTYPE html><html lang="en"><head></head><body>Not Found</body></html>
   '''html
@@ -14,7 +16,7 @@ defmodule Tableau.Router do
   plug :rerender
 
   plug Tableau.IndexHtml
-  plug Plug.Static, at: "/", from: "_site", cache_control_for_etags: "no-cache"
+  plug Plug.Static, at: "/#{basepath}", from: "_site", cache_control_for_etags: "no-cache"
 
   plug :match
   plug :dispatch


### PR DESCRIPTION
This is a quick working solution to #57 - it allows the site developer to configure a `:base_path` attribute in `config.exs`.

The `base_path` attribute is used in `router.ex` to adjust the static path, and in `Mix.Tasks.Tableau.Server` to adjust the logger message.

If the `:base_path` is not set in `config.exs`, the system behaves just as it does now.  

For my use case as described in #57, this solution works great!

If you reject this PR in favor of a better solution, no problemo.  If you want docs, or tests etc. I will supply.  Just putting this out there for ideas and feedback. 