### PR TITLE
fix: start telemetry app to handle warning logs

### DIFF
--- a/lib/mix/tasks/tableau.build.ex
+++ b/lib/mix/tasks/tableau.build.ex
@@ -10,6 +10,7 @@ defmodule Mix.Tasks.Tableau.Build do
 
   @impl Mix.Task
   def run(argv) do
+    Application.ensure_all_started(:telemetry)
     {:ok, config} = Tableau.Config.new(@config)
     token = %{site: %{config: config}}
     Mix.Task.run("app.start", ["--preload-modules"])


### PR DESCRIPTION
Fixes #61