### PR TITLE
fix: add `base_path` to config schema

### DIFF
--- a/lib/tableau/config.ex
+++ b/lib/tableau/config.ex
@@ -24,6 +24,7 @@ defmodule Tableau.Config do
         optional(:timezone) => str(),
         optional(:reload_log) => bool(),
         optional(:markdown) => list(oneof([tuple([:mdex, list()])])),
+        optional(:base_path) => str(),
         url: str()
       },
       convert: false


### PR DESCRIPTION
I wanted to use the `@site.config.base_path` for my links to make them work in different environments. The changes from #59 helped a lot, but because the field is missing in the schematic schema, it doesn't get parsed into the config struct and will be set to the default empty string.