### PR TITLE
Allow configuration of the posts and pages html converter

### DIFF
--- a/lib/tableau/extensions/page_extension/config.ex
+++ b/lib/tableau/extensions/page_extension/config.ex
@@ -3,7 +3,11 @@ defmodule Tableau.PageExtension.Config do
 
   import Schematic
 
-  defstruct enabled: true, dir: "_pages", permalink: nil, layout: nil
+  defstruct enabled: true,
+            dir: "_pages",
+            permalink: nil,
+            layout: nil,
+            html_converter: "Tableau.PostExtension.Posts.HTMLConverter"
 
   def new(input), do: unify(schematic(), input)
 
@@ -14,7 +18,8 @@ defmodule Tableau.PageExtension.Config do
         optional(:enabled) => bool(),
         optional(:dir) => str(),
         optional(:permalink) => str(),
-        optional(:layout) => str()
+        optional(:layout) => str(),
+        optional(:html_converter) => str()
       },
       convert: false
     )

--- a/lib/tableau/extensions/page_extension/pages.ex
+++ b/lib/tableau/extensions/page_extension/pages.ex
@@ -24,7 +24,10 @@ defmodule Tableau.PageExtension.Pages do
     {:ok, config} =
       Tableau.PageExtension.Config.new(@config)
 
-    opts = Keyword.put_new(opts, :html_converter, Tableau.PageExtension.Pages.HTMLConverter)
+    opts =
+      Keyword.put_new_lazy(opts, :html_converter, fn ->
+        Module.concat([config.html_converter])
+      end)
 
     config.dir
     |> Path.join("**/*.md")

--- a/lib/tableau/extensions/post_extension/config.ex
+++ b/lib/tableau/extensions/post_extension/config.ex
@@ -3,7 +3,12 @@ defmodule Tableau.PostExtension.Config do
 
   import Schematic
 
-  defstruct enabled: true, dir: "_posts", future: false, permalink: nil, layout: nil
+  defstruct enabled: true,
+            dir: "_posts",
+            future: false,
+            permalink: nil,
+            layout: nil,
+            html_converter: "Tableau.PostExtension.Posts.HTMLConverter"
 
   def new(input), do: unify(schematic(), input)
 
@@ -15,7 +20,8 @@ defmodule Tableau.PostExtension.Config do
         optional(:dir) => str(),
         optional(:future) => bool(),
         optional(:permalink) => str(),
-        optional(:layout) => str()
+        optional(:layout) => str(),
+        optional(:html_converter) => str()
       },
       convert: false
     )

--- a/lib/tableau/extensions/post_extension/posts.ex
+++ b/lib/tableau/extensions/post_extension/posts.ex
@@ -24,7 +24,10 @@ defmodule Tableau.PostExtension.Posts do
     {:ok, config} =
       Tableau.PostExtension.Config.new(@config)
 
-    opts = Keyword.put_new(opts, :html_converter, Tableau.PostExtension.Posts.HTMLConverter)
+    opts =
+      Keyword.put_new_lazy(opts, :html_converter, fn ->
+        Module.concat([config.html_converter])
+      end)
 
     config.dir
     |> Path.join("**/*.md")


### PR DESCRIPTION
Allow for the posts/pages HTMLConverter to be set as a configuration value.

This is a step along the path to allowing different markup languages
