### PR TITLE
fix: allow atom layout module names

### DIFF
--- a/lib/tableau/extensions/page_extension.ex
+++ b/lib/tableau/extensions/page_extension.ex
@@ -73,7 +73,7 @@ defmodule Tableau.PageExtension do
         optional(:enabled, true) => bool(),
         optional(:dir, "_pages") => str(),
         optional(:permalink) => str(),
-        optional(:layout) => str()
+        optional(:layout) => oneof([str(), atom()])
       }),
       input
     )
@@ -113,7 +113,7 @@ defmodule Tableau.PageExtension do
     |> Map.put(:__tableau_page_extension__, true)
     |> Map.put(:body, body)
     |> Map.put(:file, filename)
-    |> Map.put(:layout, Module.concat([front_matter.layout || pages_config.layout]))
+    |> Map.put(:layout, Module.concat([front_matter[:layout] || pages_config.layout]))
     |> Common.build_permalink(pages_config)
   end
 end

--- a/lib/tableau/extensions/post_extension.ex
+++ b/lib/tableau/extensions/post_extension.ex
@@ -81,7 +81,7 @@ defmodule Tableau.PostExtension do
         optional(:dir, "_posts") => str(),
         optional(:future, false) => bool(),
         optional(:permalink) => str(),
-        optional(:layout) => str()
+        optional(:layout) => oneof([atom(), str()])
       }),
       config
     )

--- a/test/tableau/extensions/page_extension_test.exs
+++ b/test/tableau/extensions/page_extension_test.exs
@@ -13,7 +13,7 @@ defmodule Tableau.PageExtensionTest do
 
   describe "run" do
     setup %{tmp_dir: dir} do
-      assert {:ok, config} = PageExtension.config(%{dir: dir, enabled: true})
+      assert {:ok, config} = PageExtension.config(%{dir: dir, enabled: true, layout: Blog.DefaultPageLayout})
 
       token = %{
         site: %{config: %{converters: [md: Tableau.MDExConverter]}},
@@ -195,6 +195,34 @@ defmodule Tableau.PageExtensionTest do
                    layout: Some.Layout,
                    permalink: "/articles/foo-man-chu-foo.js",
                    title: "foo man chu_foo.js",
+                   type: "articles"
+                 }
+               ]
+             } = token
+    end
+
+    test "inherits layout from page extension config", %{tmp_dir: dir, token: token} do
+      File.write(Path.join(dir, "a-page.md"), """
+      ---
+      title: missing layout key
+      type: articles
+      permalink: /:type/:title
+      ---
+
+      A great page
+      """)
+
+      assert {:ok, token} = PageExtension.run(token)
+
+      assert %{
+               pages: [
+                 %{
+                   __tableau_page_extension__: true,
+                   body: "\nA great page\n",
+                   file: ^dir <> "/a-page.md",
+                   layout: Blog.DefaultPageLayout,
+                   permalink: "/articles/missing-layout-key",
+                   title: "missing layout key",
                    type: "articles"
                  }
                ]

--- a/test/tableau/extensions/post_extension_test.exs
+++ b/test/tableau/extensions/post_extension_test.exs
@@ -13,7 +13,7 @@ defmodule Tableau.PostExtensionTest do
 
   describe "run" do
     setup %{tmp_dir: dir} do
-      assert {:ok, config} = PostExtension.config(%{dir: dir, enabled: true})
+      assert {:ok, config} = PostExtension.config(%{dir: dir, enabled: true, layout: Blog.DefaultPostLayout})
 
       token = %{
         site: %{config: %{converters: [md: Tableau.MDExConverter]}},
@@ -228,6 +228,34 @@ defmodule Tableau.PostExtensionTest do
                    layout: Blog.PostLayout,
                    permalink: "/%C2qu%C3-es-la-programaci%C3n-funcional",
                    title: "¿Qué es la programación funcional?"
+                 }
+               ]
+             } = token
+    end
+
+    test "inherits layout from post extension config", %{tmp_dir: dir, token: token} do
+      File.write(Path.join(dir, "a-post.md"), """
+      ---
+      title: Missing layout key
+      date: 2018-02-28
+      permalink: /:title
+      ---
+
+      A great post
+      """)
+
+      assert {:ok, token} = PostExtension.run(token)
+
+      assert %{
+               posts: [
+                 %{
+                   __tableau_post_extension__: true,
+                   body: "\nA great post\n",
+                   date: ~U[2018-02-28 00:00:00Z],
+                   file: ^dir <> "/a-post.md",
+                   layout: Blog.DefaultPostLayout,
+                   permalink: "/missing-layout-key",
+                   title: "Missing layout key"
                  }
                ]
              } = token


### PR DESCRIPTION
String values for layout module names are required to be supported in
the front matter, but it feels odd to require that they be strings in
config. This enables the specification of layout modules as atoms and
fixes a bug in PageExtension which required a layout value in the
front matter at all times.
