### PR TITLE
feat!: run pre-write extensions after render but before write

### DIFF
--- a/lib/tableau/extension.ex
+++ b/lib/tableau/extension.ex
@@ -84,7 +84,7 @@ defmodule Tableau.Extension do
       quote do
         def __tableau_extension_type__, do: unquote(opts)[:type]
         def __tableau_extension_key__, do: unquote(opts)[:key]
-        def __tableau_extension_enabled__, do: unquote(opts)[:enabled] || true
+        def __tableau_extension_enabled__, do: Keyword.get(unquote(opts), :enabled, true)
         def __tableau_extension_priority__, do: unquote(opts)[:priority] || 0
       end
 


### PR DESCRIPTION
Closes #107

BREAKING-CHANGE: :pre_write extensions now are run after rendering the
graph, but before writing to disk. Previously, the body content of each
page would not have been converted yet, but now it will. This should
enable anyone to modify the HTML after other extensions converter it.

perf: render the graph in parallel

fix: actually respec the "enabled" key in `use Tableau.Extension`
