### PR TITLE
feat(pages, posts): use custom converter in frontmatter (#112)

### DIFF
--- a/test/tableau/extensions/page_extension_test.exs
+++ b/test/tableau/extensions/page_extension_test.exs
@@ -228,5 +228,34 @@ defmodule Tableau.PageExtensionTest do
                ]
              } = token
     end
+
+    test "renders with a custom converter in frontmatter", %{tmp_dir: dir, token: token} do
+      File.write(Path.join(dir, "a-page.md"), """
+      ---
+      title: missing layout key
+      type: articles
+      permalink: /:type/:title
+      converter: "Tableau.MDExConverter"
+      ---
+
+      A great page
+      """)
+
+      assert {:ok, token} = PageExtension.run(token)
+
+      assert %{
+               pages: [
+                 %{
+                   __tableau_page_extension__: true,
+                   body: "\nA great page\n",
+                   file: ^dir <> "/a-page.md",
+                   layout: Blog.DefaultPageLayout,
+                   permalink: "/articles/missing-layout-key",
+                   title: "missing layout key",
+                   type: "articles"
+                 }
+               ]
+             } = token
+    end
   end
 end

--- a/test/tableau/extensions/post_extension_test.exs
+++ b/test/tableau/extensions/post_extension_test.exs
@@ -291,5 +291,37 @@ defmodule Tableau.PostExtensionTest do
                ]
              } = token
     end
+
+    test "renders with a custom converter in frontmatter", %{tmp_dir: dir, token: token} do
+      File.write(Path.join(dir, "a-post.md"), """
+      ---
+      title: foo man chu_foo.js
+      type: articles
+      layout: Some.Layout
+      date: 2023-02-01 00:01:00
+      permalink: /:type/:year/:month/:day/:title
+      converter: "Tableau.MDExConverter"
+      ---
+
+      A great post
+      """)
+
+      assert {:ok, token} = PostExtension.run(token)
+
+      assert %{
+               posts: [
+                 %{
+                   __tableau_post_extension__: true,
+                   body: "\nA great post\n",
+                   date: ~U[2023-02-01 00:01:00Z],
+                   file: ^dir <> "/a-post.md",
+                   layout: Some.Layout,
+                   permalink: "/articles/2023/02/01/foo-man-chu-foo.js",
+                   title: "foo man chu_foo.js",
+                   type: "articles"
+                 }
+               ]
+             } = token
+    end
   end
 end


### PR DESCRIPTION
Allow a page or post to specify a custom converter in the frontmatter.

The frontmatter key `:converter` is optional.  If included, it should specify a string-value of a converter module.  If not included, the default config setting will be used.

Included in this PR:
- code and documentation updates to `Tableau.PostExtension` and `Tableau.PageExtension`
- updates to `Tableau.PostExtensionTest` and `Tableau.PageExtensionTest`

This PR relates to issue #112 