### PR TITLE
feat(pages): write pages with .html permalink to corresponding file

### DIFF
--- a/lib/mix/tasks/tableau.build.ex
+++ b/lib/mix/tasks/tableau.build.ex
@@ -55,11 +55,12 @@ defmodule Mix.Tasks.Tableau.Build do
     token = mods |> extensions_for(:pre_write) |> run_extensions(token)
 
     for %{body: body, permalink: permalink} <- pages do
-      dir = Path.join(out, permalink)
+      file_path = build_file_path(out, permalink)
+      dir = Path.dirname(file_path)
 
       File.mkdir_p!(dir)
 
-      File.write!(Path.join(dir, "index.html"), body)
+      File.write!(file_path, body)
     end
 
     if File.exists?(config.include_dir) do
@@ -69,6 +70,15 @@ defmodule Mix.Tasks.Tableau.Build do
     token = mods |> extensions_for(:post_write) |> run_extensions(token)
 
     token
+  end
+
+  @file_extensions [".html"]
+  defp build_file_path(out, permalink) do
+    if Path.extname(permalink) in @file_extensions do
+      Path.join(out, permalink)
+    else
+      Path.join([out, permalink, "index.html"])
+    end
   end
 
   defp validate_config(module, raw_config) do

--- a/test/mix/tasks/tableau.build_test.exs
+++ b/test/mix/tasks/tableau.build_test.exs
@@ -194,4 +194,30 @@ defmodule Mix.Tasks.Tableau.BuildTest do
     assert File.exists?(Path.join(out, "/a-bing-bong-blog-post/index.html"))
     assert File.exists?(Path.join(out, "/some/deeply/nested/page/my-page/index.html"))
   end
+
+  @tag :tmp_dir
+  test "writes page with permalink with .html file extension to corresponding file", %{tmp_dir: out} do
+    pages = out |> Path.join("_pages") |> tap(&File.mkdir_p!/1)
+    Application.put_env(:tableau, Tableau.PageExtension, enabled: true, dir: pages)
+
+    File.write(Path.join(pages, "404.md"), """
+    ---
+    layout: Mix.Tasks.Tableau.BuildTest.RootLayout
+    title: A 404 error page
+    permalink: /404.html
+    ---
+
+    ## Ooops
+
+    Nothing here.
+    """)
+
+    with_io(:stderr, fn ->
+      with_log(fn ->
+        _documents = Build.run(["--out", out])
+      end)
+    end)
+
+    assert File.exists?(Path.join(out, "/404.html"))
+  end
 end


### PR DESCRIPTION
To create a custom 404 page with GitHub pages, you [must add a file at /404.html](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site).

So far, adding `permalink: /404` or `permalink: /404.html` to the frontmatter would result in writing the page at `/404/index.html` or `/404.html/index.html`.

With this PR, every page that has a permalink with `.html` extension is written directly to that file.

I guess you would want to make the extensions that you accept here configurable, this way you could also disable it completely (which could be the default as well).

