### PR TITLE
fix(sitemap): sitemap custom tags

### DIFF
--- a/lib/tableau/extensions/sitemap_extension.ex
+++ b/lib/tableau/extensions/sitemap_extension.ex
@@ -91,6 +91,7 @@ defmodule Tableau.SitemapExtension do
   defp prepend_sitemap_assigns(body, %{sitemap: sitemap_data}) do
     for {key, value} <- sitemap_data, reduce: body do
       acc -> ["<", key, ">", value, "</", key, ">" | acc]
+      acc -> ["<#{key}>", "#{value}", "</#{key}>" | acc]
     end
   end
 

--- a/lib/tableau/extensions/sitemap_extension.ex
+++ b/lib/tableau/extensions/sitemap_extension.ex
@@ -60,7 +60,8 @@ defmodule Tableau.SitemapExtension do
       end
 
     xml = [
-      "<urlset ",
+      ~s|<?xml version="1.0" encoding="UTF-8"?>|,
+      "<urlset",
       " ",
       ~s|xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"|,
       " ",
@@ -90,7 +91,6 @@ defmodule Tableau.SitemapExtension do
 
   defp prepend_sitemap_assigns(body, %{sitemap: sitemap_data}) do
     for {key, value} <- sitemap_data, reduce: body do
-      acc -> ["<", key, ">", value, "</", key, ">" | acc]
       acc -> ["<#{key}>", "#{value}", "</#{key}>" | acc]
     end
   end

--- a/lib/tableau/extensions/sitemap_extension.ex
+++ b/lib/tableau/extensions/sitemap_extension.ex
@@ -91,6 +91,7 @@ defmodule Tableau.SitemapExtension do
 
   defp prepend_sitemap_assigns(body, %{sitemap: sitemap_data}) do
     sitemap_data = Enum.sort(sitemap_data)
+
     for {key, value} <- sitemap_data, reduce: body do
       acc -> ["<#{key}>", "#{value}", "</#{key}>" | acc]
     end

--- a/lib/tableau/extensions/sitemap_extension.ex
+++ b/lib/tableau/extensions/sitemap_extension.ex
@@ -90,6 +90,7 @@ defmodule Tableau.SitemapExtension do
   defp prepend_lastmod(body, _), do: body
 
   defp prepend_sitemap_assigns(body, %{sitemap: sitemap_data}) do
+    sitemap_data = Enum.sort(sitemap_data)
     for {key, value} <- sitemap_data, reduce: body do
       acc -> ["<#{key}>", "#{value}", "</#{key}>" | acc]
     end

--- a/test/tableau/extensions/sitemap_extension_test.exs
+++ b/test/tableau/extensions/sitemap_extension_test.exs
@@ -23,7 +23,7 @@ defmodule Tableau.SitemapExtensionTest do
 
     SitemapExtension.run(token)
 
-    sitemap = File.read!("_site/sitemap.xml")
+    sitemap = File.read!("#{tmp_dir}/sitemap.xml")
 
     assert sitemap ===
              """

--- a/test/tableau/extensions/sitemap_extension_test.exs
+++ b/test/tableau/extensions/sitemap_extension_test.exs
@@ -1,0 +1,89 @@
+defmodule Tableau.SitemapExtensionTest do
+  use ExUnit.Case, async: true
+
+  alias Tableau.SitemapExtension
+
+  test "use _site as default out dir" do
+    token = %{
+      site: %{
+        config: %{
+          url: "http://example.com"
+        },
+        pages: [
+          %{
+            date: ~U[2018-02-28 00:00:00Z],
+            permalink: "/about",
+            title: "About"
+          }
+        ]
+      }
+    }
+
+    SitemapExtension.run(token)
+
+    sitemap = File.read!("_site/sitemap.xml")
+
+    assert Floki.parse_document!(sitemap) === [
+             {:pi, "xml", [{"version", "1.0"}, {"encoding", "UTF-8"}]},
+             {"urlset",
+              [
+                {"xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9"},
+                {"xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"},
+                {"xsi:schemalocation",
+                 "http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"}
+              ],
+              [
+                {"url", [],
+                 [
+                   {"lastmod", [], ["2018-02-28T00:00:00Z"]},
+                   {"loc", [], ["http://example.com/about"]}
+                 ]}
+              ]}
+           ]
+  end
+
+  @tag :tmp_dir
+  test "generates sitemap with optional tags", %{tmp_dir: tmp_dir} do
+    token = %{
+      out: tmp_dir,
+      site: %{
+        config: %{
+          url: "http://example.com"
+        },
+        pages: [
+          %{
+            permalink: "/about",
+            title: "About",
+            sitemap: %{
+              priority: 0.5,
+              changefreq: "monthly"
+            }
+          }
+        ]
+      }
+    }
+
+    SitemapExtension.run(token)
+
+    sitemap = File.read!("#{tmp_dir}/sitemap.xml")
+
+    assert Floki.parse_document!(sitemap) === [
+             {:pi, "xml", [{"version", "1.0"}, {"encoding", "UTF-8"}]},
+             {"urlset",
+              [
+                {"xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9"},
+                {"xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"},
+                {"xsi:schemalocation",
+                 "http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"}
+              ],
+              [
+                {"url", [],
+                 [
+                   {"changefreq", [], ["monthly"]},
+                   {"priority", [], ["0.5"]},
+                   {"loc", [], ["http://example.com/about"]}
+                 ]}
+              ]}
+           ]
+  end
+end

--- a/test/tableau/extensions/sitemap_extension_test.exs
+++ b/test/tableau/extensions/sitemap_extension_test.exs
@@ -22,14 +22,17 @@ defmodule Tableau.SitemapExtensionTest do
     SitemapExtension.run(token)
 
     sitemap = File.read!("_site/sitemap.xml")
-    assert sitemap === [~s|<?xml version="1.0" encoding="UTF-8"?>|,
-    ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
-    "<url>",
-    "<lastmod>2018-02-28T00:00:00Z</lastmod>",
-    "<loc>http://example.com/about</loc>",
-    "</url>",
-    "</urlset>"]
-    |> :erlang.iolist_to_binary()
+
+    assert sitemap ===
+             :erlang.iolist_to_binary([
+               ~s|<?xml version="1.0" encoding="UTF-8"?>|,
+               ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
+               "<url>",
+               "<lastmod>2018-02-28T00:00:00Z</lastmod>",
+               "<loc>http://example.com/about</loc>",
+               "</url>",
+               "</urlset>"
+             ])
   end
 
   @tag :tmp_dir
@@ -57,14 +60,16 @@ defmodule Tableau.SitemapExtensionTest do
 
     sitemap = File.read!("#{tmp_dir}/sitemap.xml")
 
-    assert sitemap === [~s|<?xml version="1.0" encoding="UTF-8"?>|,
-    ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
-    "<url>",
-    "<priority>0.5</priority>",
-    "<changefreq>monthly</changefreq>",
-    "<loc>http://example.com/about</loc>",
-    "</url>",
-    "</urlset>"]
-    |> :erlang.iolist_to_binary()
+    assert sitemap ===
+             :erlang.iolist_to_binary([
+               ~s|<?xml version="1.0" encoding="UTF-8"?>|,
+               ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
+               "<url>",
+               "<priority>0.5</priority>",
+               "<changefreq>monthly</changefreq>",
+               "<loc>http://example.com/about</loc>",
+               "</url>",
+               "</urlset>"
+             ])
   end
 end

--- a/test/tableau/extensions/sitemap_extension_test.exs
+++ b/test/tableau/extensions/sitemap_extension_test.exs
@@ -7,7 +7,8 @@ defmodule Tableau.SitemapExtensionTest do
     token = %{
       site: %{
         config: %{
-          url: "http://example.com"
+          url: "http://example.com",
+          out_dir: "_site"
         },
         pages: [
           %{
@@ -24,7 +25,7 @@ defmodule Tableau.SitemapExtensionTest do
     sitemap = File.read!("_site/sitemap.xml")
 
     assert sitemap ===
-             :erlang.iolist_to_binary([
+             IO.iodata_to_binary([
                ~s|<?xml version="1.0" encoding="UTF-8"?>|,
                ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
                "<url>",
@@ -38,9 +39,9 @@ defmodule Tableau.SitemapExtensionTest do
   @tag :tmp_dir
   test "generates sitemap with optional tags", %{tmp_dir: tmp_dir} do
     token = %{
-      out: tmp_dir,
       site: %{
         config: %{
+          out_dir: tmp_dir,
           url: "http://example.com"
         },
         pages: [
@@ -61,7 +62,7 @@ defmodule Tableau.SitemapExtensionTest do
     sitemap = File.read!("#{tmp_dir}/sitemap.xml")
 
     assert sitemap ===
-             :erlang.iolist_to_binary([
+             IO.iodata_to_binary([
                ~s|<?xml version="1.0" encoding="UTF-8"?>|,
                ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
                "<url>",

--- a/test/tableau/extensions/sitemap_extension_test.exs
+++ b/test/tableau/extensions/sitemap_extension_test.exs
@@ -22,24 +22,14 @@ defmodule Tableau.SitemapExtensionTest do
     SitemapExtension.run(token)
 
     sitemap = File.read!("_site/sitemap.xml")
-
-    assert Floki.parse_document!(sitemap) === [
-             {:pi, "xml", [{"version", "1.0"}, {"encoding", "UTF-8"}]},
-             {"urlset",
-              [
-                {"xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9"},
-                {"xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"},
-                {"xsi:schemalocation",
-                 "http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"}
-              ],
-              [
-                {"url", [],
-                 [
-                   {"lastmod", [], ["2018-02-28T00:00:00Z"]},
-                   {"loc", [], ["http://example.com/about"]}
-                 ]}
-              ]}
-           ]
+    assert sitemap === [~s|<?xml version="1.0" encoding="UTF-8"?>|,
+    ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
+    "<url>",
+    "<lastmod>2018-02-28T00:00:00Z</lastmod>",
+    "<loc>http://example.com/about</loc>",
+    "</url>",
+    "</urlset>"]
+    |> :erlang.iolist_to_binary()
   end
 
   @tag :tmp_dir
@@ -67,23 +57,14 @@ defmodule Tableau.SitemapExtensionTest do
 
     sitemap = File.read!("#{tmp_dir}/sitemap.xml")
 
-    assert Floki.parse_document!(sitemap) === [
-             {:pi, "xml", [{"version", "1.0"}, {"encoding", "UTF-8"}]},
-             {"urlset",
-              [
-                {"xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9"},
-                {"xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"},
-                {"xsi:schemalocation",
-                 "http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"}
-              ],
-              [
-                {"url", [],
-                 [
-                   {"changefreq", [], ["monthly"]},
-                   {"priority", [], ["0.5"]},
-                   {"loc", [], ["http://example.com/about"]}
-                 ]}
-              ]}
-           ]
+    assert sitemap === [~s|<?xml version="1.0" encoding="UTF-8"?>|,
+    ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
+    "<url>",
+    "<priority>0.5</priority>",
+    "<changefreq>monthly</changefreq>",
+    "<loc>http://example.com/about</loc>",
+    "</url>",
+    "</urlset>"]
+    |> :erlang.iolist_to_binary()
   end
 end

--- a/test/tableau/extensions/sitemap_extension_test.exs
+++ b/test/tableau/extensions/sitemap_extension_test.exs
@@ -3,12 +3,13 @@ defmodule Tableau.SitemapExtensionTest do
 
   alias Tableau.SitemapExtension
 
-  test "use _site as default out dir" do
+  @tag :tmp_dir
+  test "use _site as default out dir", %{tmp_dir: tmp_dir} do
     token = %{
       site: %{
         config: %{
           url: "http://example.com",
-          out_dir: "_site"
+          out_dir: tmp_dir
         },
         pages: [
           %{

--- a/test/tableau/extensions/sitemap_extension_test.exs
+++ b/test/tableau/extensions/sitemap_extension_test.exs
@@ -25,15 +25,15 @@ defmodule Tableau.SitemapExtensionTest do
     sitemap = File.read!("_site/sitemap.xml")
 
     assert sitemap ===
-             IO.iodata_to_binary([
-               ~s|<?xml version="1.0" encoding="UTF-8"?>|,
-               ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
-               "<url>",
-               "<lastmod>2018-02-28T00:00:00Z</lastmod>",
-               "<loc>http://example.com/about</loc>",
-               "</url>",
-               "</urlset>"
-             ])
+             """
+             <?xml version="1.0" encoding="UTF-8"?>\
+             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">\
+             <url>\
+             <lastmod>2018-02-28T00:00:00Z</lastmod>\
+             <loc>http://example.com/about</loc>\
+             </url>\
+             </urlset>\
+             """
   end
 
   @tag :tmp_dir
@@ -62,15 +62,15 @@ defmodule Tableau.SitemapExtensionTest do
     sitemap = File.read!("#{tmp_dir}/sitemap.xml")
 
     assert sitemap ===
-             IO.iodata_to_binary([
-               ~s|<?xml version="1.0" encoding="UTF-8"?>|,
-               ~s|<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">|,
-               "<url>",
-               "<priority>0.5</priority>",
-               "<changefreq>monthly</changefreq>",
-               "<loc>http://example.com/about</loc>",
-               "</url>",
-               "</urlset>"
-             ])
+             """
+             <?xml version="1.0" encoding="UTF-8"?>\
+             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">\
+             <url>\
+             <priority>0.5</priority>\
+             <changefreq>monthly</changefreq>\
+             <loc>http://example.com/about</loc>\
+             </url>\
+             </urlset>\
+             """
   end
 end


### PR DESCRIPTION
The Sitemap extension allows defining custom tags, for example, using frontmatter:
  ```yaml
  title: "Some Page"
  sitemap:
    priority: 0.8
    changefreq: hourly
  ```

Unfortunately, with the latest changes, it stopped working and crashes the whole build process. This happens because `File.write!` expects `iodata()`, but in this case, it receives an list of mixed types. I fixed this by interpolating values into a string.

While fixing this bug, I also noticed that the sitemap and feed are always saved to the _site directory. This isn't an issue for me since I use the default output directory, but I thought it would be nice to allow specifying a custom output directory. This is the second part of this PR.