### PR TITLE
Fixing doc: `configs` and `import`

### DIFF
--- a/lib/tableau.ex
+++ b/lib/tableau.ex
@@ -14,7 +14,10 @@ defmodule Tableau do
   ### Example
 
   ```elixir
-  # configs/config.exs
+  # config/config.exs
+
+  import Config
+
   config :tableau, :config,
     url: "http://localhost:8080",
     timezone: "America/Indiana/Indianapolis",

--- a/lib/tableau/extensions/page_extension.ex
+++ b/lib/tableau/extensions/page_extension.ex
@@ -54,7 +54,10 @@ defmodule Tableau.PageExtension do
   Currently the `Tableau.MDExConverter` is the only builtin converter, but you are free to write your own!
 
   ```elixir
-  # configs/config.exs
+  # config/config.exs
+
+  import Config
+
   config :tableau, :config,
     converters: [
       md: Tableau.MDExConverter,

--- a/lib/tableau/extensions/post_extension.ex
+++ b/lib/tableau/extensions/post_extension.ex
@@ -60,7 +60,10 @@ defmodule Tableau.PostExtension do
   Currently the `Tableau.MDExConverter` is the only builtin converter, but you are free to write your own!
 
   ```elixir
-  # configs/config.exs
+  # config/config.exs
+
+  import Config
+
   config :tableau, :config,
     converters: [
       md: Tableau.MDExConverter,


### PR DESCRIPTION
I'm being a foolish man and standing up the site by scratch without using the template or generators… and this hung me up for a bit this evening.

I could be totally wrong, but I think the file has to be in `config/config.exs`, and that you have to `import Config` in the file, otherwise the error you'll find is related to not `url:`.