### PR TITLE
fix(rss): don't enable by default

### DIFF
--- a/lib/tableau/extensions/rss_extension.ex
+++ b/lib/tableau/extensions/rss_extension.ex
@@ -42,7 +42,7 @@ defmodule Tableau.RSSExtension do
     ]
   ```
   """
-  use Tableau.Extension, key: :rss, priority: 200
+  use Tableau.Extension, key: :rss, priority: 200, enabled: false
 
   import Schematic
 


### PR DESCRIPTION
I'm still standing up a site from scratch, and I noticed the recurrence of https://github.com/elixir-tools/tableau/issues/131, but this time after doing some dummy debugging, it was the RSS extension.

Fixes #149