### PR TITLE
docs(layout): change `use` and illustrate

### DIFF
--- a/lib/tableau/layout.ex
+++ b/lib/tableau/layout.ex
@@ -6,7 +6,7 @@ defmodule Tableau.Layout do
 
   ```elixir
   defmodule MySite.SidebarLayout do
-    use Tableau.Layout
+    use Tableau.Layout, layout: MySite.RootLayout
 
     def template(assigns) do
       """


### PR DESCRIPTION
While reading the docs, it seemed weird that the docs for Tableau.Layout was using the `use Tableau.Page` illustration from Page. I _think_ it's just a copypasta error, and this is what you were intending to show?

I could be *totally* incorrect.