### PR TITLE
feat(tags): slugify tag names

### DIFF
--- a/lib/tableau.ex
+++ b/lib/tableau.ex
@@ -10,6 +10,7 @@ defmodule Tableau do
   * `:converters` - mapping of file extensions to converter module. Defaults to `[md: Tableau.MDExConverter]`
   * `:markdown` - keyword
       * `:mdex` - keyword - Options to pass to `MDEx.to_html/2`
+  * `:slug` - keyword - Options to pass to `Slug.slugify/2`
 
   ### Example
 
@@ -24,6 +25,9 @@ defmodule Tableau do
     converters: [
       md: Tableau.MDExConverter,
       dj: MySite.DjotConverter
+    ],
+    slug: [
+      lowercase: false
     ],
     markdown: [
       mdex: [

--- a/lib/tableau/config.ex
+++ b/lib/tableau/config.ex
@@ -10,6 +10,7 @@ defmodule Tableau.Config do
     out_dir: "_site",
     timezone: "Etc/UTC",
     reload_log: false,
+    slug: [],
     converters: [md: Tableau.MDExConverter],
     markdown: [mdex: []]
   ]
@@ -32,6 +33,13 @@ defmodule Tableau.Config do
         optional(:reload_log) => bool(),
         optional(:converters) => keyword(values: atom()),
         optional(:markdown) => keyword(values: list()),
+        optional(:slug) =>
+          keyword(%{
+            optional(:separator) => oneof([str(), int()]),
+            optional(:lowercase) => bool(),
+            optional(:truncate) => int(),
+            optional(:ignore) => oneof([str(), list(oneof([str(), int()]))])
+          }),
         optional(:base_path) => str(),
         url: str()
       },

--- a/lib/tableau/extensions/common.ex
+++ b/lib/tableau/extensions/common.ex
@@ -9,6 +9,27 @@ defmodule Tableau.Extension.Common do
   end
 
   @doc """
+  Transform strings from any language into slugs using `Slug.slugify/1`.
+
+  Returns the original string if the slug cannot be generated.
+  """
+  def slugify(string, overrides \\ [])
+
+  def slugify(string, %{site: %{config: config}}) do
+    Slug.slugify(string, config.slug) || string
+  end
+
+  def slugify(string, config) when is_map(config) do
+    slugify(string)
+  end
+
+  def slugify(string, overrides) do
+    {:ok, config} = Tableau.Config.get()
+
+    Slug.slugify(string, Keyword.merge(config.slug, overrides)) || string
+  end
+
+  @doc """
   Build content entries from a list of paths.
 
   Content should contain YAML frontmatter, with the body from the file passed to the callback.

--- a/test/tableau/extensions/tag_extension_test.exs
+++ b/test/tableau/extensions/tag_extension_test.exs
@@ -6,20 +6,35 @@ defmodule Tableau.TagExtensionTest do
   alias Tableau.TagExtension
   alias Tableau.TagExtensionTest.Layout
 
+  describe "config" do
+    test "handles tag slugs correctly" do
+      config =
+        %{
+          enabled: true,
+          layout: Layout,
+          permalink: "/tags",
+          tags: %{"C++" => [slug: "c-plus-plus"]}
+        }
+
+      assert {:ok, ^config} = TagExtension.config(config)
+    end
+  end
+
   describe "run" do
     test "creates tag pages and tags key" do
       posts = [
         # dedups tags
         post(1, tags: ["post", "post"]),
         # post can have multiple tags, includes posts from same tag
-        post(2, tags: ["til", "post"]),
+        # tags will be converted to slugs for linking
+        post(2, tags: ["til", "post", "Today I Learned", "C++"]),
         post(3, tags: ["recipe"])
       ]
 
       token = %{
         posts: posts,
         graph: Graph.new(),
-        extensions: %{tag: %{config: %{layout: Layout, permalink: "/tags"}}}
+        extensions: %{tag: %{config: %{layout: Layout, permalink: "/tags", tags: %{"C++" => [slug: "c-plus-plus"]}}}}
       }
 
       assert {:ok, token} = TagExtension.pre_build(token)
@@ -27,9 +42,21 @@ defmodule Tableau.TagExtensionTest do
 
       assert %{
                tags: %{
-                 %{tag: "post", title: "post", permalink: "/tags/post"} => [%{title: "Post 2"}, %{title: "Post 1"}],
-                 %{tag: "recipe", title: "recipe", permalink: "/tags/recipe"} => [%{title: "Post 3"}],
-                 %{tag: "til", title: "til", permalink: "/tags/til"} => [%{title: "Post 2"}]
+                 %{tag: "post", title: "post", permalink: "/tags/post", slug: "post"} => [
+                   %{title: "Post 2"},
+                   %{title: "Post 1"}
+                 ],
+                 %{tag: "recipe", title: "recipe", permalink: "/tags/recipe", slug: "recipe"} => [%{title: "Post 3"}],
+                 %{tag: "til", title: "til", permalink: "/tags/til", slug: "til"} => [%{title: "Post 2"}],
+                 %{
+                   tag: "Today I Learned",
+                   title: "Today I Learned",
+                   permalink: "/tags/today-i-learned",
+                   slug: "today-i-learned"
+                 } => [
+                   %{title: "Post 2"}
+                 ],
+                 %{tag: "C++", title: "C++", permalink: "/tags/c-plus-plus", slug: "c-plus-plus"} => [%{title: "Post 2"}]
                },
                graph: graph
              } = token
@@ -39,6 +66,8 @@ defmodule Tableau.TagExtensionTest do
       assert Enum.any?(vertices, &page_with_permalink?(&1, "/tags/post"))
       assert Enum.any?(vertices, &page_with_permalink?(&1, "/tags/recipe"))
       assert Enum.any?(vertices, &page_with_permalink?(&1, "/tags/til"))
+      assert Enum.any?(vertices, &page_with_permalink?(&1, "/tags/today-i-learned"))
+      assert Enum.any?(vertices, &page_with_permalink?(&1, "/tags/c-plus-plus"))
 
       assert Layout in vertices
     end


### PR DESCRIPTION
This change makes tags with spaces or special characters play nicely with the Web. By default, tag display values will be converted to `slugs` using [Slugify][slugify] when building permalinks.

The tag extension configuration has been extended to have a `:tags` option with a map of display values to options (the only supported option is `:slug`):

```elixir
config :tableau, Tableau.TagExtension,
  tags: %{
    "C++" => [slug: "c-plus-plus"],
  }
```

This will be used instead of automatic slug conversion. Automatic slug conversion can be configured in the main Tableau configuration with the `:slug` keyword option, which is passed directly to [Slugify][slugify].

Other extension writers may use `Tableau.Extension.Common.slugify/2`.

[slugify]: https://hexdocs.pm/slugify/Slug.html

Resolves: #160
