### PR TITLE
docs: add netoum.com and oranje-patrimoine.fr to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Documentation can be found at <https://hexdocs.pm/tableau>.
 | [https://adrienanselme.com/](https://adrienanselme.com/)   | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | Tailwind   |          | [adanselm/adanselm.github.io](https://github.com/adanselm/adanselm.github.io)     |
 | [acrogenesis.com](https://acrogenesis.com)                  | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | CSS        |          | [acrogenesis/acrogenesis.com](https://github.com/acrogenesis/acrogenesis.com)     |
 | [elixirchangelog.com](https://elixirchangelog.com)         | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | CSS        |          | [crbelaus/elixirchangelog.com](https://github.com/crbelaus/elixirchangelog.com)     |
+| [oranje-patrimoine.fr](https://oranje-patrimoine.fr/)         | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | Tailwind        |          | [corex-ui/corex](https://github.com/corex-ui/corex)     |
+| [netoum.com](https://netoum.com/)         | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | Tailwind        |          | [corex-ui/corex](https://github.com/corex-ui/corex)     |
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Documentation can be found at <https://hexdocs.pm/tableau>.
 | [https://adrienanselme.com/](https://adrienanselme.com/)   | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | Tailwind   |          | [adanselm/adanselm.github.io](https://github.com/adanselm/adanselm.github.io)     |
 | [acrogenesis.com](https://acrogenesis.com)                  | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | CSS        |          | [acrogenesis/acrogenesis.com](https://github.com/acrogenesis/acrogenesis.com)     |
 | [elixirchangelog.com](https://elixirchangelog.com)         | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | CSS        |          | [crbelaus/elixirchangelog.com](https://github.com/crbelaus/elixirchangelog.com)     |
-| [oranje-patrimoine.fr](https://oranje-patrimoine.fr/)         | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | Tailwind        |          | [corex-ui/corex](https://github.com/corex-ui/corex)     |
-| [netoum.com](https://netoum.com/)         | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | Tailwind        |          | [corex-ui/corex](https://github.com/corex-ui/corex)     |
+| [oranje-patrimoine.fr](https://oranje-patrimoine.fr/)         | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | Tailwind        |          | N/A     |
+| [netoum.com](https://netoum.com/)         | [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) | Tailwind        |          | N/A     |
 
 ## Getting Started
 


### PR DESCRIPTION
This PR aims at adding 2 additional site examples build with Tableau: [netoum.com](https://netoum.com/) and [oranje-patrimoine.fr](https://oranje-patrimoine.fr/)